### PR TITLE
Barvinok support

### DIFF
--- a/build-with-barvinok.sh
+++ b/build-with-barvinok.sh
@@ -12,7 +12,7 @@ BARVINOK_GIT_REV="barvinok-0.41"
 NPROCS=30
 
 if true; then
-  rm -Rf "$PREFIX" "$BUILD_DIR"
+  rm -Rf "$BUILD_DIR"
 
   mkdir "$BUILD_DIR"
   cd "$BUILD_DIR"

--- a/build-with-barvinok.sh
+++ b/build-with-barvinok.sh
@@ -31,7 +31,7 @@ if true; then
   git checkout $BARVINOK_GIT_REV
   ./get_submodules.sh
   sh autogen.sh
-  ./configure --prefix="$PREFIX" --with-ntl-prefix="$PREFIX" --enable-shared-barvinok
+  ./configure --prefix="$PREFIX" --with-ntl-prefix="$PREFIX" --enable-shared-barvinok --with-pet=bundled
 
   make -j$NPROCS
   make install


### PR DESCRIPTION
I suggest the following two changes in this PR:
- bundling `pet` with barvinok build, so `parse_file` function for auto detection of SCOPs becomes available in `iscc`.
- not deleting `$PREFIX` directory. `PREFIX`'s path is in the home directory of the current user and it might be more convenient to change it to somewhere else like `/usr/local` by creating a symlink. In this case, deleting does not make sense.