### PR TITLE
Support isl_bool pointer arguments

### DIFF
--- a/gen_wrap.py
+++ b/gen_wrap.py
@@ -1381,7 +1381,7 @@ def write_method_wrapper(gen, cls_name, meth):
                     check('raise Error("call to \\"{0}\\" failed: %s" '
                             '% _get_last_error_str(_ctx_data))'.format(meth.c_name))
             else:
-                raise SignatureNotSupported("int *")
+                raise SignatureNotSupported("isl_bool *")
 
         elif arg.base_type == "isl_val" and arg.ptr == "*" and arg_idx > 0:
             # {{{ val input argument

--- a/test/test_isl.py
+++ b/test/test_isl.py
@@ -309,6 +309,18 @@ def test_align_spaces():
     result = isl.align_spaces(m1, m2)
     assert result.get_var_dict() == m2.get_var_dict()
 
+    a1 = isl.Aff("[t0, t1, t2] -> { [(32)] }")
+    a2 = isl.Aff("[t1, t0] -> { [(0)] }")
+
+    with pytest.raises(isl.Error):
+        a1_aligned = isl.align_spaces(a1, a2)
+
+    a1_aligned = isl.align_spaces(a1, a2, obj_bigger_ok=True)
+    a2_aligned = isl.align_spaces(a2, a1)
+
+    assert a1_aligned == isl.Aff("[t1, t0, t2] -> { [(32)] }")
+    assert a2_aligned == isl.Aff("[t1, t0, t2] -> { [(0)] }")
+
 
 def test_pass_numpy_int():
     np = pytest.importorskip("numpy")
@@ -320,8 +332,24 @@ def test_pass_numpy_int():
     print(c1)
 
 
+def test_isl_align_two():
+    a1 = isl.Aff("[t0, t1, t2] -> { [(32)] }")
+    a2 = isl.Aff("[t1, t0] -> { [(0)] }")
+
+    a1_aligned, a2_aligned = isl.align_two(a1, a2)
+    assert a1_aligned == isl.Aff("[t1, t0, t2] -> { [(32)] }")
+    assert a2_aligned == isl.Aff("[t1, t0, t2] -> { [(0)] }")
+
+    b1 = isl.BasicSet("[n0, n1, n2] -> { [i0, i1] : }")
+    b2 = isl.BasicSet("[n0, n2, n1, n3] -> { [i1, i0, i2] : }")
+
+    b1_aligned, b2_aligned = isl.align_two(b1, b2)
+    assert b1_aligned == isl.BasicSet("[n0, n2, n1, n3] -> { [i1, i0, i2] :  }")
+    assert b2_aligned == isl.BasicSet("[n0, n2, n1, n3] -> { [i1, i0, i2] :  }")
+
+
 def test_bound():
-    print(isl.PwQPolynomial("""[n, m] -> {[i, j] -> i * m + j : 
+    print(isl.PwQPolynomial("""[n, m] -> {[i, j] -> i * m + j :
             0 <= i < n and 0 <= j < m}""").bound(isl.fold.min))
     print(isl.PwQPolynomial("""[n, m] -> {[i, j] -> i * m + j :
             0 <= i < n and 0 <= j < m}""").bound(isl.fold.max))

--- a/test/test_isl.py
+++ b/test/test_isl.py
@@ -319,6 +319,9 @@ def test_pass_numpy_int():
     c1 = c0.set_constant_val(np.int32(5))
     print(c1)
 
+def test_bound():
+    print(isl.PwQPolynomial('[n, m] -> {[i, j] -> i * m + j : 0 <= i < n and 0 <= j < m}').bound(isl.fold.min))
+    print(isl.PwQPolynomial('[n, m] -> {[i, j] -> i * m + j : 0 <= i < n and 0 <= j < m}').bound(isl.fold.max))
 
 if __name__ == "__main__":
     import sys

--- a/test/test_isl.py
+++ b/test/test_isl.py
@@ -319,9 +319,13 @@ def test_pass_numpy_int():
     c1 = c0.set_constant_val(np.int32(5))
     print(c1)
 
+
 def test_bound():
-    print(isl.PwQPolynomial('[n, m] -> {[i, j] -> i * m + j : 0 <= i < n and 0 <= j < m}').bound(isl.fold.min))
-    print(isl.PwQPolynomial('[n, m] -> {[i, j] -> i * m + j : 0 <= i < n and 0 <= j < m}').bound(isl.fold.max))
+    print(isl.PwQPolynomial("""[n, m] -> {[i, j] -> i * m + j : 
+            0 <= i < n and 0 <= j < m}""").bound(isl.fold.min))
+    print(isl.PwQPolynomial("""[n, m] -> {[i, j] -> i * m + j :
+            0 <= i < n and 0 <= j < m}""").bound(isl.fold.max))
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
Hi! Thank you for very useful library!
I recently found that some functions taking a `isl_bool *` as an argument (e.g., `isl_pw_qpolynomial_bound`) are not supported by islpy. This is because of a recent update of isl 0.20 which changes `int*` argument to `isl_bool*` arguments.
The following is an excerpt from the release note.
>  Several functions returning an extra boolean value through an int * argument
now do so through an isl_bool * argument. The returned values are the same,
only the type of the pointer has been changed

This PR is update for that change. Because there seems to be no functions which takes `int*` arguments in ISL any more, I simply changed the case for `int*` to `isl_bool*`.