### PR TITLE
add isl_bool and fix enum entries with python keyword

### DIFF
--- a/islpy/__init__.py
+++ b/islpy/__init__.py
@@ -107,6 +107,7 @@ AstBuild = _isl.AstBuild
 
 error = _isl.error
 stat = _isl.stat
+bool = _isl.bool
 dim_type = _isl.dim_type
 schedule_node_type = _isl.schedule_node_type
 ast_expr_op_type = _isl.ast_expr_op_type

--- a/src/wrapper/wrap_isl.cpp
+++ b/src/wrapper/wrap_isl.cpp
@@ -68,6 +68,12 @@ PYBIND11_MODULE(_isl, m)
     .ENUM_VALUE(isl_stat_, ok)
     ;
 
+  py::enum_<isl_bool>(m, "bool")
+    .ENUM_VALUE(isl_bool_, error)
+    .ENUM_VALUE(isl_bool_, true)
+    .ENUM_VALUE(isl_bool_, false)
+    ;
+
   py::enum_<isl_dim_type>(m, "dim_type")
     .ENUM_VALUE(isl_dim_, cst)
     .ENUM_VALUE(isl_dim_, param)
@@ -95,9 +101,9 @@ PYBIND11_MODULE(_isl, m)
 
   py::enum_<isl_ast_expr_op_type>(m, "ast_expr_op_type")
     .ENUM_VALUE(isl_ast_expr_op_, error)
-    .ENUM_VALUE(isl_ast_expr_op_, and)
+    .value("and_", isl_ast_expr_op_and)
     .ENUM_VALUE(isl_ast_expr_op_, and_then)
-    .ENUM_VALUE(isl_ast_expr_op_, or)
+    .value("or_", isl_ast_expr_op_or)
     .ENUM_VALUE(isl_ast_expr_op_, or_else)
     .ENUM_VALUE(isl_ast_expr_op_, max)
     .ENUM_VALUE(isl_ast_expr_op_, min)
@@ -138,8 +144,8 @@ PYBIND11_MODULE(_isl, m)
 
   py::enum_<isl_ast_node_type>(m, "ast_node_type")
     .ENUM_VALUE(isl_ast_node_, error)
-    .ENUM_VALUE(isl_ast_node_, for)
-    .ENUM_VALUE(isl_ast_node_, if)
+    .value("for_", isl_ast_node_for)
+    .value("if_", isl_ast_node_if)
     .ENUM_VALUE(isl_ast_node_, block)
     .ENUM_VALUE(isl_ast_node_, user)
     ;

--- a/src/wrapper/wrap_isl.cpp
+++ b/src/wrapper/wrap_isl.cpp
@@ -73,6 +73,7 @@ PYBIND11_MODULE(_isl, m)
     .ENUM_VALUE(isl_bool_, true)
     .ENUM_VALUE(isl_bool_, false)
     ;
+  py::implicitly_convertible<int, isl_bool>();
 
   py::enum_<isl_dim_type>(m, "dim_type")
     .ENUM_VALUE(isl_dim_, cst)


### PR DESCRIPTION
This commit :
1. adds basic support for `isl_bool`.
2. fixe some enum entries that are python keywords.

For 1), I think it will be better if we can add automatic type cast between `isl_bool` and python int/bool types.
For 2), I'm not sure if it was the original author's intention to use those python keywords since the enums are indeed still accessible through `getattr(node, "for")`, but IMO the older islpy API that appends underscore to keywords is better.