### PR TITLE
add special case on isl_bool for callback return type's cast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         -   name: "Main Script"
             run: |
                 curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/master/prepare-and-run-flake8.sh
-                . ./prepare-and-run-flake8.sh "$(basename $GITHUB_REPOSITORY)" test
+                . ./prepare-and-run-flake8.sh "$(basename $GITHUB_REPOSITORY)" test gen_wrap.py
 
     pytest:
         name: Pytest on Py${{ matrix.python-version }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,6 +67,6 @@ Documentation:
 Flake8:
   script:
   - curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/master/prepare-and-run-flake8.sh
-  - . ./prepare-and-run-flake8.sh "$CI_PROJECT_NAME" test
+  - . ./prepare-and-run-flake8.sh "$CI_PROJECT_NAME" test gen_wrap.py
   tags:
   - python3

--- a/gen_wrap.py
+++ b/gen_wrap.py
@@ -1354,12 +1354,12 @@ def write_exposer(outf, meth, arg_names, doc_str):
     #if meth.is_static:
     #    doc_str = "(static method)\n" + doc_str
 
-    doc_str_arg = ", \"%s\"" % doc_str.replace("\n", "\\n")
+    doc_str_arg = ', "%s"' % doc_str.replace("\n", "\\n")
 
     wrap_class = CLASS_MAP.get(meth.cls, meth.cls)
 
     for exp_py_name in [py_name]+extra_py_names:
-        outf.write("wrap_%s.def%s(\"%s\", %s%s);\n" % (
+        outf.write('wrap_%s.def%s("%s", %s%s);\n' % (
             wrap_class, "_static" if meth.is_static else "",
             exp_py_name, func_name, args_str+doc_str_arg))
 

--- a/gen_wrap.py
+++ b/gen_wrap.py
@@ -750,13 +750,19 @@ def get_callback(cb_name, cb):
                     throw isl::error("callback returned None");
                 }
                 """)
-        post_call.append("""
-                else
-                    return py::cast<%(ret_type)s>(retval);
-            """ % {
-                "ret_type": ret_type,
-                }
-            )
+        if cb.return_base_type == "isl_bool":
+            post_call.append("""
+                    else
+                        return static_cast<isl_bool>(py::cast<int>(retval));
+                """)
+        else:
+            post_call.append("""
+                    else
+                        return py::cast<%(ret_type)s>(retval);
+                """ % {
+                    "ret_type": ret_type,
+                    }
+                )
         if cb.return_base_type == "isl_bool":
             error_return = "isl_bool_error"
         else:

--- a/gen_wrap.py
+++ b/gen_wrap.py
@@ -813,7 +813,9 @@ def get_callback(cb_name, cb):
             {
               std::cout << "[islpy warning] A Python exception occurred in "
                 "a call back function, ignoring:" << std::endl;
+              err.restore();
               PyErr_Print();
+              PyErr_Clear();
               return %(error_return)s;
             }
             catch (std::exception &e)

--- a/gen_wrap.py
+++ b/gen_wrap.py
@@ -752,13 +752,13 @@ def get_callback(cb_name, cb):
                 """)
         if cb.return_base_type == "isl_bool":
             post_call.append("""
-                    else
-                        return static_cast<isl_bool>(py::cast<int>(retval));
+                else
+                    return static_cast<isl_bool>(py::cast<bool>(retval));
                 """)
         else:
             post_call.append("""
-                    else
-                        return py::cast<%(ret_type)s>(retval);
+                else
+                    return py::cast<%(ret_type)s>(retval);
                 """ % {
                     "ret_type": ret_type,
                     }

--- a/test/test_isl.py
+++ b/test/test_isl.py
@@ -414,9 +414,15 @@ def test_remove_map_if_callback():
         m.get_tuple_name(isl.dim_type.in_) == "B")
     assert umap2 == isl.UnionMap.read_from_str(ctx, "{A[0] -> [1]}")
 
+
+def test_remove_map_if_callback_exc():
+    pytest.skip("https://github.com/inducer/islpy/pull/33#issuecomment-705165253")
+    ctx = isl.Context()
+
+    umap = isl.UnionMap.read_from_str(ctx, "{A[0] -> [1]; B[1] -> [2]}")
+
     def callback_throws_exception(m):
-        del m
-        assert False
+        1/0
 
     with pytest.raises(isl.Error):
         umap3 = umap.remove_map_if(callback_throws_exception)

--- a/test/test_isl.py
+++ b/test/test_isl.py
@@ -391,6 +391,7 @@ def test_ast_node_list_free():
 
     body.block_get_children()
 
+
 def test_remove_map_if_callback():
 
     ctx = isl.Context()

--- a/test/test_isl.py
+++ b/test/test_isl.py
@@ -412,6 +412,7 @@ def test_remove_map_if_callback():
         umap3 = umap.remove_map_if(callback_throws_exception)
         del umap3
 
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:

--- a/test/test_isl.py
+++ b/test/test_isl.py
@@ -392,19 +392,25 @@ def test_ast_node_list_free():
     body.block_get_children()
 
 def test_remove_map_if_callback():
-    umap = isl.UnionMap("{A[0] -> [1]; B[1] -> [2]}")
+
+    ctx = isl.Context()
+
+    umap = isl.UnionMap.read_from_str(ctx, "{A[0] -> [1]; B[1] -> [2]}")
 
     umap1 = umap.remove_map_if(lambda m: False)
     assert umap1 == umap, "map should not change"
 
     umap2 = umap.remove_map_if(lambda m:
         m.get_tuple_name(isl.dim_type.in_) == "B")
-    assert umap2 == isl.UnionMap("{A[0] -> [1]}")
+    assert umap2 == isl.UnionMap.read_from_str(ctx, "{A[0] -> [1]}")
 
     def callback_throws_exception(m):
+        del m
         assert False
-    umap3 = umap.remove_map_if(callback_throws_exception)
 
+    with pytest.raises(isl.Error):
+        umap3 = umap.remove_map_if(callback_throws_exception)
+        # del umap
 
 if __name__ == "__main__":
     import sys

--- a/test/test_isl.py
+++ b/test/test_isl.py
@@ -410,7 +410,7 @@ def test_remove_map_if_callback():
 
     with pytest.raises(isl.Error):
         umap3 = umap.remove_map_if(callback_throws_exception)
-        # del umap
+        del umap3
 
 if __name__ == "__main__":
     import sys

--- a/test/test_isl.py
+++ b/test/test_isl.py
@@ -391,6 +391,20 @@ def test_ast_node_list_free():
 
     body.block_get_children()
 
+def test_remove_map_if_callback():
+    umap = isl.UnionMap("{A[0] -> [1]; B[1] -> [2]}")
+
+    umap1 = umap.remove_map_if(lambda m: False)
+    assert umap1 == umap, "map should not change"
+
+    umap2 = umap.remove_map_if(lambda m:
+        m.get_tuple_name(isl.dim_type.in_) == "B")
+    assert umap2 == isl.UnionMap("{A[0] -> [1]}")
+
+    def callback_throws_exception(m):
+        assert False
+    umap3 = umap.remove_map_if(callback_throws_exception)
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
This implements a fix for isl_bool in callback handling (as mentioned in #30).
