### PR TITLE
Invalid python function name fix

### DIFF
--- a/gen_wrap.py
+++ b/gen_wrap.py
@@ -412,6 +412,11 @@ def preprocess_with_macros(macro_header_contents, code):
 # {{{ FunctionData (includes parser)
 
 class FunctionData:
+
+    INVALID_PY_IDENTIFIER_RENAMING_MAP = {
+        "2exp": "two_exp"
+    }
+
     def __init__(self, include_dirs):
         self.classes_to_methods = {}
         self.include_dirs = include_dirs
@@ -656,8 +661,12 @@ class FunctionData:
         if name in PYTHON_RESERVED_WORDS:
             name = name + "_"
 
+        name = self.INVALID_PY_IDENTIFIER_RENAMING_MAP.get(name, name)
+
         if name[0].isdigit():
-            name = "fun_" + name
+            print(f"SKIP: {class_name} {name} "
+                   "(unhandled invalid python identifier)")
+            return
 
         if class_name == "options":
             assert name.startswith("set_") or name.startswith("get_"), (name, c_name)


### PR DESCRIPTION
This fixes a small problem with automatically generated python name for the function `isl_val_2exp`.
Before the fix, the python name was "2exp" and was invalid (and probably got hidden by pybind since that function will not be accessible).

Currently I just chose to escape the name with a `fun_` prefix. Let me know if there's a better choice?