### PR TITLE
add more upcasts

### DIFF
--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -57,11 +57,14 @@ lists:
 Called with          Argument Type
 ==================== ==========================
 :class:`BasicSet`    :class:`Set`
-:class:`BasicMap`    :class:`Map`
 :class:`Set`         :class:`UnionSet`
+:class:`BasicMap`    :class:`Map`
 :class:`Map`         :class:`UnionMap`
-:class:`Space`       :class:`LocalSpace`
 :class:`Aff`         :class:`PwAff`
+:class:`PwAff`       :class:`UnionPwAff`
+:class:`MultiAff`    :class:`PwMultiAff`
+:class:`PwMultiAff`  :class:`UnionPwMultiAff`
+:class:`Space`       :class:`LocalSpace`
 ==================== ==========================
 
 as well as casts contained in the transitive closure of this 'casting graph'.

--- a/islpy/__init__.py
+++ b/islpy/__init__.py
@@ -934,10 +934,10 @@ def _add_functionality():
 
     for args_triple in [
             (BasicSet, Set, Set.from_basic_set),
-            (BasicMap, Map, Map.from_basic_map),
+            (Set, UnionSet, UnionSet.from_set),
             (BasicSet, UnionSet, lambda x: UnionSet.from_set(Set.from_basic_set(x))),
 
-            (Set, UnionSet, UnionSet.from_set),
+            (BasicMap, Map, Map.from_basic_map),
             (Map, UnionMap, UnionMap.from_map),
             (BasicMap, UnionMap, lambda x: UnionMap.from_map(Map.from_basic_map(x))),
 

--- a/islpy/__init__.py
+++ b/islpy/__init__.py
@@ -935,13 +935,20 @@ def _add_functionality():
     for args_triple in [
             (BasicSet, Set, Set.from_basic_set),
             (BasicMap, Map, Map.from_basic_map),
+            (BasicSet, UnionSet, lambda x: UnionSet.from_set(Set.from_basic_set(x))),
+
             (Set, UnionSet, UnionSet.from_set),
             (Map, UnionMap, UnionMap.from_map),
-
-            (BasicSet, UnionSet, lambda x: UnionSet.from_set(Set.from_basic_set(x))),
             (BasicMap, UnionMap, lambda x: UnionMap.from_map(Map.from_basic_map(x))),
 
             (Aff, PwAff, PwAff.from_aff),
+            (PwAff, UnionPwAff, UnionPwAff.from_pw_aff),
+            (Aff, UnionPwAff, UnionPwAff.from_aff),
+
+            (MultiAff, PwMultiAff, PwMultiAff.from_multi_aff),
+            (PwMultiAff, UnionPwMultiAff, UnionPwMultiAff.from_pw_multi_aff),
+            (MultiAff, UnionPwMultiAff, UnionPwMultiAff.from_multi_aff),
+
             (Space, LocalSpace, LocalSpace.from_space),
             ]:
         add_upcasts(*args_triple)

--- a/src/wrapper/wrap_isl.cpp
+++ b/src/wrapper/wrap_isl.cpp
@@ -185,11 +185,20 @@ PYBIND11_MODULE(_isl, m)
   islpy_expose_part3(m);
 
   py::implicitly_convertible<isl::basic_set, isl::set>();
-  py::implicitly_convertible<isl::basic_map, isl::map>();
-  py::implicitly_convertible<isl::basic_set, isl::union_set>();
-  py::implicitly_convertible<isl::basic_map, isl::union_map>();
   py::implicitly_convertible<isl::set, isl::union_set>();
+  py::implicitly_convertible<isl::basic_set, isl::union_set>();
+
+  py::implicitly_convertible<isl::basic_map, isl::map>();
   py::implicitly_convertible<isl::map, isl::union_map>();
-  py::implicitly_convertible<isl::space, isl::local_space>();
+  py::implicitly_convertible<isl::basic_map, isl::union_map>();
+
   py::implicitly_convertible<isl::aff, isl::pw_aff>();
+  py::implicitly_convertible<isl::pw_aff, isl::union_pw_aff>();
+  py::implicitly_convertible<isl::aff, isl::union_pw_aff>();
+
+  py::implicitly_convertible<isl::multi_aff, isl::pw_multi_aff>();
+  py::implicitly_convertible<isl::pw_multi_aff, isl::union_pw_multi_aff>();
+  py::implicitly_convertible<isl::multi_aff, isl::union_pw_multi_aff>();
+
+  py::implicitly_convertible<isl::space, isl::local_space>();
 }

--- a/src/wrapper/wrap_isl.hpp
+++ b/src/wrapper/wrap_isl.hpp
@@ -214,11 +214,25 @@ namespace isl
     WRAP_CLASS_CONTENT(pw_aff);
     MAKE_CAST_CTOR(pw_aff, aff, isl_pw_aff_from_aff);
   };
-  WRAP_CLASS(union_pw_aff);
+  struct union_pw_aff
+  {
+    WRAP_CLASS_CONTENT(union_pw_aff);
+    MAKE_CAST_CTOR(union_pw_aff, pw_aff, isl_union_pw_aff_from_pw_aff);
+  };
+
   WRAP_CLASS(multi_aff);
+  struct pw_multi_aff
+  {
+    WRAP_CLASS_CONTENT(pw_multi_aff);
+    MAKE_CAST_CTOR(pw_multi_aff, multi_aff, isl_pw_multi_aff_from_multi_aff);
+  };
+  struct union_pw_multi_aff
+  {
+    WRAP_CLASS_CONTENT(union_pw_multi_aff);
+    MAKE_CAST_CTOR(union_pw_multi_aff, pw_multi_aff, isl_union_pw_multi_aff_from_pw_multi_aff);
+  };
+
   WRAP_CLASS(multi_pw_aff);
-  WRAP_CLASS(pw_multi_aff);
-  WRAP_CLASS(union_pw_multi_aff);
   WRAP_CLASS(multi_union_pw_aff);
 
   WRAP_CLASS(id);

--- a/src/wrapper/wrap_isl_part1.cpp
+++ b/src/wrapper/wrap_isl_part1.cpp
@@ -91,16 +91,19 @@ void islpy_expose_part1(py::module &m)
   wrap_pw_aff.def(py::init<isl::aff &>());
 
   MAKE_WRAP(union_pw_aff, UnionPwAff);
+  wrap_union_pw_aff.def(py::init<isl::pw_aff &>());
 
   MAKE_WRAP(multi_id, MultiId);
 
   MAKE_WRAP(multi_aff, MultiAff);
 
-  MAKE_WRAP(multi_pw_aff, MultiPwAff);
-
   MAKE_WRAP(pw_multi_aff, PwMultiAff);
+  wrap_pw_multi_aff.def(py::init<isl::multi_aff &>());
 
   MAKE_WRAP(union_pw_multi_aff, UnionPwMultiAff);
+  wrap_union_pw_multi_aff.def(py::init<isl::pw_multi_aff &>());
+
+  MAKE_WRAP(multi_pw_aff, MultiPwAff);
 
   MAKE_WRAP(multi_union_pw_aff, MultiUnionPwAff);
 


### PR DESCRIPTION
This PR adds the following upcasts (#75):

- pw_aff -> union_pw_aff
- multi_aff -> pw_multi_aff
- pw_multi_aff -> union_pw_multi_aff
- and transitive closures of these casts.

The intention is that the upcasts would have the following mirror (between 1. and 2.):

1. basic_set -> set -> union_set
2. (multi_)aff -> pw_(multi_)aff -> union_pw_(multi_)aff

In particular, I ignored all the aff types where "multi_" is at the leftmost position.

**Note**: I replayed #78 because there were something funny with my local git history (which I fixed with rebase). But GitHub was not happy with me simply rebasing then force push to that PR, so I am creating this one instead. 