### PR TITLE
Drop hash fallback via string (closes gh-89)

### DIFF
--- a/islpy/__init__.py
+++ b/islpy/__init__.py
@@ -307,23 +307,14 @@ def _add_functionality():
         getattr(prn, f"print_{self._base_name}")(self)
         return f'{type(self).__name__}("{prn.get_str()}")'
 
-    def generic_hash(self):
-        return hash((type(self), str(self)))
-
-    def generic_isl_hash(self):
-        return self.get_hash()
-
     for cls in ALL_CLASSES:
         if (hasattr(cls, "_base_name")
                 and hasattr(Printer, f"print_{cls._base_name}")):
             cls.__str__ = generic_str
             cls.__repr__ = generic_repr
 
-            if not hasattr(cls, "get_hash"):
-                cls.__hash__ = generic_hash
-
-        if hasattr(cls, "get_hash"):
-            cls.__hash__ = generic_isl_hash
+        if not hasattr(cls, "__hash__"):
+            raise AssertionError(f"not hashable: {cls}")
 
     # }}}
 


### PR DESCRIPTION
There's quite the list of types for which the generic hash was being used:

```
generic hash for: <class 'islpy._isl.Aff'>                                                                              
generic hash for: <class 'islpy._isl.AffList'>   
generic hash for: <class 'islpy._isl.AstExpr'>  
generic hash for: <class 'islpy._isl.AstExprList'>
generic hash for: <class 'islpy._isl.AstNode'>       
generic hash for: <class 'islpy._isl.AstNodeList'>  
generic hash for: <class 'islpy._isl.BasicMap'>         
generic hash for: <class 'islpy._isl.BasicMapList'>                                                                     
generic hash for: <class 'islpy._isl.BasicSet'>         
generic hash for: <class 'islpy._isl.BasicSetList'>
generic hash for: <class 'islpy._isl.Constraint'>     
generic hash for: <class 'islpy._isl.ConstraintList'> 
generic hash for: <class 'islpy._isl.Id'>        
generic hash for: <class 'islpy._isl.IdList'>             
generic hash for: <class 'islpy._isl.LocalSpace'>   
generic hash for: <class 'islpy._isl.Map'>              
generic hash for: <class 'islpy._isl.MapList'>                                                                                           
generic hash for: <class 'islpy._isl.MultiAff'>         
generic hash for: <class 'islpy._isl.MultiId'>        
generic hash for: <class 'islpy._isl.MultiPwAff'>     
generic hash for: <class 'islpy._isl.MultiUnionPwAff'>
generic hash for: <class 'islpy._isl.MultiVal'>    
generic hash for: <class 'islpy._isl.Point'>              
generic hash for: <class 'islpy._isl.PwAff'>         
generic hash for: <class 'islpy._isl.PwAffList'>      
generic hash for: <class 'islpy._isl.PwMultiAff'>         
generic hash for: <class 'islpy._isl.PwMultiAffList'>    
generic hash for: <class 'islpy._isl.PwQPolynomial'>                                                                    
generic hash for: <class 'islpy._isl.PwQPolynomialFold'>
generic hash for: <class 'islpy._isl.PwQPolynomialFoldList'>                                                                                                                                    
generic hash for: <class 'islpy._isl.PwQPolynomialList'>
generic hash for: <class 'islpy._isl.QPolynomial'>                                                                      
generic hash for: <class 'islpy._isl.QPolynomialFold'>  
generic hash for: <class 'islpy._isl.QPolynomialList'>
generic hash for: <class 'islpy._isl.Schedule'>           
generic hash for: <class 'islpy._isl.ScheduleConstraints'>
generic hash for: <class 'islpy._isl.ScheduleNode'>                                                                                      
generic hash for: <class 'islpy._isl.Set'>                
generic hash for: <class 'islpy._isl.SetList'>                      
generic hash for: <class 'islpy._isl.Space'>                        
generic hash for: <class 'islpy._isl.UnionAccessInfo'>              
generic hash for: <class 'islpy._isl.UnionFlow'>                    
generic hash for: <class 'islpy._isl.UnionMap'>                     
generic hash for: <class 'islpy._isl.UnionMapList'>                 
generic hash for: <class 'islpy._isl.UnionPwAff'>                   
generic hash for: <class 'islpy._isl.UnionPwAffList'>               
generic hash for: <class 'islpy._isl.UnionPwMultiAff'>              
generic hash for: <class 'islpy._isl.UnionPwMultiAffList'>                                      
generic hash for: <class 'islpy._isl.UnionPwQPolynomial'>                                       
generic hash for: <class 'islpy._isl.UnionPwQPolynomialFold'>                                                                                                                                   
generic hash for: <class 'islpy._isl.UnionSet'>                                                 
generic hash for: <class 'islpy._isl.UnionSetList'>                                             
generic hash for: <class 'islpy._isl.Val'>                                                      
generic hash for: <class 'islpy._isl.ValList'>                                                  
generic hash for: <class 'islpy._isl.Vec'>        
```

These would become unhashable with this PR, which isn't ideal.

cc @thisiscam 