### PR TITLE
Add barvinok rpath during linking

### DIFF
--- a/build-with-barvinok.sh
+++ b/build-with-barvinok.sh
@@ -83,9 +83,9 @@ cd islpy
   --isl-inc-dir=$PREFIX/include \
   --isl-lib-dir=$PREFIX/lib \
   --use-barvinok
-CPP_LD_EXTRA_FLAGS=""
+CPP_LD_EXTRA_FLAGS="-Wl,-rpath,${PREFIX}/lib"
 if [[ "$(uname)" == "Darwin" ]]; then
-  CPP_LD_EXTRA_FLAGS="-undefined dynamic_lookup"
+  CPP_LD_EXTRA_FLAGS+="-undefined dynamic_lookup"
 fi
 CC=g++ LDSHARED="g++ -shared ${CPP_LD_EXTRA_FLAGS}" python setup.py install
 


### PR DESCRIPTION
I found this helpful as I no longer have to do `export LD_LIBRARY_PATH=$BUILD_DIR/lib:$LD_LIBRARY_PATH"` after running `./build-with-barvinok.sh`.

Also, thanks a lot for sharing the installation script, was very helpful!