### PR TITLE
Fix compilation error with ISLError definition

### DIFF
--- a/src/wrapper/wrap_isl.cpp
+++ b/src/wrapper/wrap_isl.cpp
@@ -15,7 +15,7 @@ PYBIND11_MODULE(_isl, m)
   py::options options;
   options.disable_function_signatures();
 
-  static py::exception<isl::error> ISLError(m, "Error", NULL);
+  static py::exception<isl::error> ISLError(m, "Error", nullptr);
   py::register_exception_translator(
         [](std::exception_ptr p)
         {


### PR DESCRIPTION
A recent change to pybind11 (https://github.com/pybind/pybind11/commit/1d811910777491ddf40660a2324a3a862dfc5e04) removes implicit conversions of "0" to a `pybind11::handle`, which the definition of `ISLError` relied on. We should explicitly use a `nullptr` anyway, which is compatible with newer and older pybind11 versions.