### PR TITLE
gen_wrap: make sure to put const into function sigs in gen-wrap*.inc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,8 @@ jobs:
     barvinok:
         name: "Test barvinok build script"
         runs-on: ubuntu-latest
+        env:
+            GITHUB_HEAD_REPOSITORY: ${{github.event.pull_request.head.repo.full_name}}
         steps:
         -   uses: actions/checkout@v3
         -

--- a/build-with-barvinok.sh
+++ b/build-with-barvinok.sh
@@ -28,8 +28,8 @@ if true; then
   cd "$BUILD_DIR"
 
   rm -Rf  islpy
-  if test "$GITHUB_HEAD_REF" != "" && test "$GITHUB_REPOSITORY" != ""; then
-    with_echo git clone --recursive https://github.com/$GITHUB_REPOSITORY.git -b "$GITHUB_HEAD_REF"
+  if test "$GITHUB_HEAD_REF" != "" && test "$GITHUB_HEAD_REPOSITORY" != ""; then
+    with_echo git clone --recursive https://github.com/$GITHUB_HEAD_REPOSITORY.git -b "$GITHUB_HEAD_REF"
   elif test "$CI_SERVER_NAME" = "GitLab" && test "$CI_COMMIT_REF_NAME" != ""; then
     with_echo git clone --recursive https://gitlab.tiker.net/inducer/islpy.git -b "$CI_COMMIT_REF_NAME"
   else
@@ -67,11 +67,11 @@ if true; then
     --enable-shared-barvinok \
     --with-pet=no
 
-  BARVNOK_ADDITIONAL_MAKE_ARGS=""
+  BARVINOK_ADDITIONAL_MAKE_ARGS=""
   if [ "$(uname)" == "Darwin" ]; then
-    BARVNOK_ADDITIONAL_MAKE_ARGS=CFLAGS="-Wno-error=implicit-function-declaration"
+    BARVINOK_ADDITIONAL_MAKE_ARGS=CFLAGS="-Wno-error=implicit-function-declaration"
   fi
-  make $BARVNOK_ADDITIONAL_MAKE_ARGS -j$NPROCS
+  make $BARVINOK_ADDITIONAL_MAKE_ARGS -j$NPROCS
   make install
 fi
 

--- a/gen_wrap.py
+++ b/gen_wrap.py
@@ -288,7 +288,7 @@ FUNC_PTR_RE = re.compile(r"""
     re.VERBOSE)
 STRUCT_DECL_RE = re.compile(
         r"(__isl_export\s+)?struct\s+(__isl_export\s+)?([a-z_A-Z0-9]+)\s*;")
-ARG_RE = re.compile(r"^((?:\w+)\s+)+(\**)\s*(\w+)$")
+ARG_RE = re.compile(r"^((?:const\s+)?(?:\w+\s+)+)(\**)\s*(\w+)$")
 INLINE_SEMICOLON_RE = re.compile(r"\;[ \t]*(?=\w)")
 SUBCLASS_RE = re.compile(
         r"__isl_subclass\s*"

--- a/gen_wrap.py
+++ b/gen_wrap.py
@@ -918,6 +918,8 @@ def write_wrapper(outf, meth):
             doc_cls = arg.base_type
             if doc_cls.startswith("isl_"):
                 doc_cls = doc_cls[4:]
+            if doc_cls == "unsigned long":
+                doc_cls = "int"
 
             docs.append(f":param {arg.name}: :class:`{doc_cls}`")
 


### PR DESCRIPTION
Found while working on #107. Function signatures in gen-wrap*.inc never included the `const` in e.g. `void foo(const char *name){}`.