### PR TITLE
Work around build errors due to incomplete pyproject.toml

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,8 +24,11 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.1
         # (here: set these in pyproject.toml to the extent possible)
-        # env:
-        #   CIBW_SOME_OPTION: value
+        # (Note: An existing pyproject.toml file will override setup.py in
+        #  recent setuptools versions, thus pyproject.toml needs to
+        #  specify the complete build systems in that case.)
+        env:
+          CIBW_SKIP: "*-win-* [cp]p3[67]-*"
         #    ...
         # with:
         #   package-dir: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[tool.cibuildwheel]
-
-skip = "*-win-* [cp]p3[67]-*"


### PR DESCRIPTION
For recent setuptools versions, the `pyproject.toml` file appears to override `setup.py`, such that some dependencies will not be installed, leading to a missing `pybind11` dependency.

Another option might be to replicate the dependencies in `pyproject.toml`, but it needs a way to specify a dependency for the (local) `aksetup_helper` module, which may not be possible (see https://github.com/pypa/setuptools/discussions/2951).


```console
$ python -m pip install -e . -v
Using pip 23.1.2 from /Users/mdiener/Work/emirge/miniforge3/envs/ceesd/lib/python3.11/site-packages/pip (python 3.11)
Obtaining file:///Users/mdiener/Work/emirge/islpy
  Running command pip subprocess to install build dependencies
  Collecting setuptools>=40.8.0
    Using cached setuptools-68.0.0-py3-none-any.whl (804 kB)
  Collecting wheel
    Using cached wheel-0.40.0-py3-none-any.whl (64 kB)
  Installing collected packages: wheel, setuptools
  Successfully installed setuptools-68.0.0 wheel-0.40.0
  Installing build dependencies ... done
  Running command Checking if build backend supports build_editable
  Checking if build backend supports build_editable ... done
  Running command Getting requirements to build editable
  ---------------------------------------------------------------------------
  Pybind11 is not installed.
  ---------------------------------------------------------------------------
  Very likely, the build process after this message will fail.

  Simply press Ctrl+C and type
  python -m pip install pybind11
  to fix this. If you don't, the build will continue
  in a few seconds.

  [1] https://pybind11.readthedocs.io/en/stable/
  ---------------------------------------------------------------------------
  Continuing in 10 seconds...

$ python -m pip install pybind11
Requirement already satisfied: pybind11 in /Users/mdiener/Work/emirge/miniforge3/envs/ceesd/lib/python3.11/site-packages (2.10.4)

$ rm pyproject.toml

$ python -m pip install -e . -v
[works normally]
```