### PR TITLE
nanobind: optimize build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-11]
-      fail-fast: false
 
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +22,7 @@ jobs:
           submodules: recursive
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.15.0
+        uses: pypa/cibuildwheel@v2.12.1
         # (here: set these in pyproject.toml to the extent possible)
         # env:
         #   CIBW_SOME_OPTION: value

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11]
+        os: [ubuntu-20.04, macos-11]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-22.04, macos-11]
 
     steps:
       - uses: actions/checkout@v3
@@ -22,10 +22,10 @@ jobs:
           submodules: recursive
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
+        uses: pypa/cibuildwheel@v2.12.3
         # (here: set these in pyproject.toml to the extent possible)
-        env:
-          VERBOSE: 1
+        # env:
+        #   CIBW_SOME_OPTION: value
         #    ...
         # with:
         #   package-dir: .

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-22.04, macos-11]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +23,7 @@ jobs:
           submodules: recursive
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
+        uses: pypa/cibuildwheel@v2.15.0
         # (here: set these in pyproject.toml to the extent possible)
         # env:
         #   CIBW_SOME_OPTION: value

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11]
+        os: [ubuntu-20.04, macos-11]
 
     steps:
       - uses: actions/checkout@v3
@@ -24,8 +24,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.1
         # (here: set these in pyproject.toml to the extent possible)
-        # env:
-        #   CIBW_SOME_OPTION: value
+        env:
+          VERBOSE: 1
         #    ...
         # with:
         #   package-dir: .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,16 @@ execute_process(
 list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
 find_package(nanobind CONFIG REQUIRED)
 
+IF(DEFINED ENV{CIBUILDWHEEL})
+  set(NOMINSIZE "")
+else()
+  set(NOMINSIZE "NOMINSIZE")
+endif()
+
 nanobind_add_module(
   _isl
   NB_STATIC # Build static libnanobind (the extension module itself remains a shared library)
-  NOMINSIZE # Optimize for speed, not for size
+  ${NOMINSIZE} # Optimize for speed, not for size
   LTO       # Enable LTO
   src/wrapper/wrap_isl.cpp
   src/wrapper/wrap_isl_part1.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(nanobind CONFIG REQUIRED)
 nanobind_add_module(
   _isl
   NB_STATIC # Build static libnanobind (the extension module itself remains a shared library)
-  NOMINSIZE # Optimize for speed, not for size
+  #NOMINSIZE # Optimize for speed, not for size
   #LTO       # Enable LTO
   src/wrapper/wrap_isl.cpp
   src/wrapper/wrap_isl_part1.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(nanobind CONFIG REQUIRED)
 nanobind_add_module(
   _isl
   NB_STATIC # Build static libnanobind (the extension module itself remains a shared library)
-  #NOMINSIZE # Optimize for speed, not for size
+  NOMINSIZE # Optimize for speed, not for size
   LTO       # Enable LTO
   src/wrapper/wrap_isl.cpp
   src/wrapper/wrap_isl_part1.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ nanobind_add_module(
   _isl
   NB_STATIC # Build static libnanobind (the extension module itself remains a shared library)
   #NOMINSIZE # Optimize for speed, not for size
-  #LTO       # Enable LTO
+  LTO       # Enable LTO
   src/wrapper/wrap_isl.cpp
   src/wrapper/wrap_isl_part1.cpp
   src/wrapper/wrap_isl_part2.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ nanobind_add_module(
   _isl
   NB_STATIC # Build static libnanobind (the extension module itself remains a shared library)
   NOMINSIZE # Optimize for speed, not for size
-  LTO       # Enable LTO
+  #LTO       # Enable LTO
   src/wrapper/wrap_isl.cpp
   src/wrapper/wrap_isl_part1.cpp
   src/wrapper/wrap_isl_part2.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ find_package(nanobind CONFIG REQUIRED)
 nanobind_add_module(
   _isl
   NB_STATIC # Build static libnanobind (the extension module itself remains a shared library)
+  NOMINSIZE # Optimize for speed, not for size
+  LTO       # Enable LTO
   src/wrapper/wrap_isl.cpp
   src/wrapper/wrap_isl_part1.cpp
   src/wrapper/wrap_isl_part2.cpp

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,11 @@ def get_config_schema():
             IncludeDir, LibraryDir, Libraries,
             Switch, StringListOption)
 
-    default_cxxflags = []
+    default_cxxflags = [
+            # Required for pybind11:
+            # https://pybind11.readthedocs.io/en/stable/faq.html#someclass-declared-with-greater-visibility-than-the-type-of-its-field-someclass-member-wattributes
+            "-fvisibility=hidden"
+            ]
 
     return ConfigSchema([
         Switch("USE_SHIPPED_ISL", True, "Use included copy of isl"),

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,7 @@ def get_config_schema():
             IncludeDir, LibraryDir, Libraries,
             Switch, StringListOption)
 
-    default_cxxflags = [
-            # Required for pybind11:
-            # https://pybind11.readthedocs.io/en/stable/faq.html#someclass-declared-with-greater-visibility-than-the-type-of-its-field-someclass-member-wattributes
-            "-fvisibility=hidden"
-            ]
+    default_cxxflags = []
 
     return ConfigSchema([
         Switch("USE_SHIPPED_ISL", True, "Use included copy of isl"),


### PR DESCRIPTION
This further increases the speed of the nanobind-built islpy for the [microbenchmark](https://github.com/inducer/islpy/pull/107#issuecomment-1714408756) on M1, especially when building with the shipped ISL/imath:

- pybind11: 85s
- nanobind in #107: 57s
- With this PR: 45s

Library size increases from 6.0 MByte to 7.6 MByte.

Also removes the manual addition of the `-fvisibility=hidden` flag, which nanobind already adds. 
