### PR TITLE
nanobind: disable warnings regarding deprecated ISL functions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
         env:
         # (here: set these in pyproject.toml to the extent possible)
             CIBW_BUILD_VERBOSITY: 1
-            VERBOSE: 1
+            CIBW_BEFORE_BUILD: export VERBOSE=1
         # with:
         #   package-dir: .
         #   output-dir: wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,10 +23,11 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.3
+        env:
         # (here: set these in pyproject.toml to the extent possible)
-        # env:
         #   CIBW_SOME_OPTION: value
-        #    ...
+            PIP_VERBOSE: 1
+            VERBOSE: 1
         # with:
         #   package-dir: .
         #   output-dir: wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,8 +25,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.12.3
         env:
         # (here: set these in pyproject.toml to the extent possible)
-        #   CIBW_SOME_OPTION: value
-            PIP_VERBOSE: 1
+            CIBW_BUILD_VERBOSITY: 1
             VERBOSE: 1
         # with:
         #   package-dir: .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ nanobind_add_module(
   ${ISL_SOURCES}
 )
 
+set_source_files_properties(src/wrapper/wrap_isl_part1.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+set_source_files_properties(src/wrapper/wrap_isl_part2.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+set_source_files_properties(src/wrapper/wrap_isl_part3.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+
 if(USE_IMATH_FOR_MP)
   target_compile_definitions(_isl PRIVATE USE_IMATH_FOR_MP=1)
 endif()


### PR DESCRIPTION
Avoids warnings of the type:

```
In file included from /Users/mdiener/Work/emirge/islpy/src/wrapper/wrap_isl_part2.cpp:5:
    /Users/mdiener/Work/emirge/islpy/src/wrapper/gen-wrap-part2.inc:12872:19: warning: 'isl_set_align_divs' is deprecated [-Wdeprecated-declarations]
    isl_set *result = isl_set_align_divs(auto_arg_self->m_data);
                      ^
    /Users/mdiener/Work/emirge/islpy/isl/include/isl/set.h:466:1: note: 'isl_set_align_divs' has been explicitly marked deprecated here
    ISL_DEPRECATED
    ^
    /Users/mdiener/Work/emirge/islpy/isl/include/isl/ctx.h:104:39: note: expanded from macro 'ISL_DEPRECATED'
    #define ISL_DEPRECATED  __attribute__((__deprecated__))
```

Also makes cibuildwheel more verbose.