### PR TITLE
MANIFEST.in: add CMakeLists.txt

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,7 +46,9 @@ jobs:
           submodules: recursive
 
       - name: Build sdist
-        run: pipx run build --sdist
+        run: |
+          pipx --version
+          pipx run build --sdist
 
       - uses: actions/upload-artifact@v3
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -32,6 +32,7 @@ include configure.py
 include Makefile.in
 include aksetup_helper.py
 include README_SETUP.txt
+include CMakeLists.txt
 
 include README.rst
 include CITATION.cff


### PR DESCRIPTION
As far as I can tell, the sdist builds now with this change.

~~Edit: Not sure that actually makes a difference.~~

Edit2: It does make a difference, see e.g. the builds [with this PR](https://github.com/inducer/islpy/actions/runs/6224821262/job/16893867750?pr=118) and with [main](https://github.com/inducer/islpy/actions/runs/6217121722/job/16871809537).