### PR TITLE
work around nominsize issue

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           # CIBW_SOME_OPTION: value
           CMAKE_BUILD_PARALLEL_LEVEL: 3
+          CIBW_BUILD_VERBOSITY: 1
           VERBOSE: 1
         #    ...
         # with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           # CIBW_SOME_OPTION: value
           CMAKE_BUILD_PARALLEL_LEVEL: 3
+          VERBOSE: 1
         #    ...
         # with:
         #   package-dir: .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ nanobind_add_module(
 # Work around https://github.com/inducer/islpy/issues/120.
 # See https://stackoverflow.com/questions/43554227/extern-inline-func-results-in-undefined-reference-error
 # for some context.
-set_source_files_properties(${ISL_SOURCES} PROPERTIES COMPILE_OPTIONS -U__USE_EXTERN_INLINES)
+set_source_files_properties(${ISL_SOURCES} PROPERTIES COMPILE_DEFINITIONS __OPTIMIZE_SIZE__)
 
 if(USE_IMATH_FOR_MP)
   target_compile_definitions(_isl PRIVATE USE_IMATH_FOR_MP=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ nanobind_add_module(
   ${ISL_SOURCES}
 )
 
+# Work around https://github.com/inducer/islpy/issues/120
 target_compile_options(_isl PRIVATE -fno-inline)
 
 if(USE_IMATH_FOR_MP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.18...3.22)
+cmake_minimum_required(VERSION 3.15...3.27)
 project(islpy)
 find_package(Python 3.8 COMPONENTS Interpreter Development.Module REQUIRED)
 
 # Force Release build by default
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  set(CMAKE_BUILD_TYPE Release CACHE STRING Choose the type of build. FORCE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ nanobind_add_module(
 )
 
 # Work around https://github.com/inducer/islpy/issues/120
-target_compile_options(_isl PRIVATE -fno-inline)
+set_source_files_properties(${ISL_SOURCES} PROPERTIES COMPILE_OPTIONS -U__USE_EXTERN_INLINES)
 
 if(USE_IMATH_FOR_MP)
   target_compile_definitions(_isl PRIVATE USE_IMATH_FOR_MP=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,16 +15,10 @@ execute_process(
 list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
 find_package(nanobind CONFIG REQUIRED)
 
-IF(DEFINED ENV{CIBUILDWHEEL})
-  set(NOMINSIZE "")
-else()
-  set(NOMINSIZE "NOMINSIZE")
-endif()
-
 nanobind_add_module(
   _isl
   NB_STATIC # Build static libnanobind (the extension module itself remains a shared library)
-  ${NOMINSIZE} # Optimize for speed, not for size
+  NOMINSIZE # Optimize for speed, not for size
   LTO       # Enable LTO
   src/wrapper/wrap_isl.cpp
   src/wrapper/wrap_isl_part1.cpp
@@ -32,6 +26,8 @@ nanobind_add_module(
   src/wrapper/wrap_isl_part3.cpp
   ${ISL_SOURCES}
 )
+
+target_compile_options(_isl PRIVATE -fno-inline)
 
 if(USE_IMATH_FOR_MP)
   target_compile_definitions(_isl PRIVATE USE_IMATH_FOR_MP=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,9 @@ nanobind_add_module(
   ${ISL_SOURCES}
 )
 
-# Work around https://github.com/inducer/islpy/issues/120
+# Work around https://github.com/inducer/islpy/issues/120.
+# See https://stackoverflow.com/questions/43554227/extern-inline-func-results-in-undefined-reference-error
+# for some context.
 set_source_files_properties(${ISL_SOURCES} PROPERTIES COMPILE_OPTIONS -U__USE_EXTERN_INLINES)
 
 if(USE_IMATH_FOR_MP)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ skip = "*-win-* [cp]p3[67]-*"
 requires = [
     "setuptools>=42,<64",  # https://github.com/scikit-build/scikit-build/pull/737#issuecomment-1215573830
     "wheel>=0.34.2",
-    "cmake>=3.18<=3.22",
+    "cmake>=3.18",
     "scikit-build",
     "nanobind",
     "ninja",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     "cmake>=3.18<=3.22",
     "scikit-build",
     "nanobind",
-    "make",
+    "ninja",
     "pcpp",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixes #120.


~~Unfortunately, this reduces performance substantially for the [microbenchmark](https://github.com/inducer/islpy/pull/107#issuecomment-1714408756) (M1):~~
~~- Without this PR: 42s~~
~~- With this PR: 56s~~

With the workaround in https://github.com/inducer/islpy/pull/121/commits/eb62cde751be3519e1069b04a69908ea8cb61963, performance remains the same as before.

This effectively disables the inline implementations of the `strtoimax`, `strtoumax`,
`wcstoimax` and `wcstoumax` functions, which were removed completely in later glibc versions (2.33, https://github.com/bminor/glibc/commit/e182654151a0f6ebbe628c8f2f6b041c69adbac1).

_Please squash._