### PR TITLE
cibw: update for 3.12, Mac M1

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,12 +17,17 @@ jobs:
         os: [ubuntu-20.04, macos-11]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.16.2
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.3
+        run: python -m cibuildwheel --output-dir wheelhouse
         # (here: set these in pyproject.toml to the extent possible)
         env:
           # CIBW_SOME_OPTION: value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-# Needed for full C++17 support
+[tool.cibuildwheel.macos]
+archs = "x86_64 arm64"
+
 [tool.cibuildwheel.macos.environment]
+# Needed for full C++17 support
 MACOSX_DEPLOYMENT_TARGET = "10.14"


### PR DESCRIPTION
Based on https://github.com/inducer/pyopencl/pull/704.

As another positive side effect, this also supports building locally with https://github.com/nektos/act now (at least the Linux wheels).