### PR TITLE
Add mark node to ast_node_type enum

### DIFF
--- a/src/wrapper/wrap_isl.cpp
+++ b/src/wrapper/wrap_isl.cpp
@@ -181,6 +181,7 @@ NB_MODULE(_isl, m)
     .value("if_", isl_ast_node_if)
     .ENUM_VALUE(isl_ast_node_, block)
     .ENUM_VALUE(isl_ast_node_, user)
+    .ENUM_VALUE(isl_ast_node_, mark)
     ;
 
   py::enum_<isl_ast_loop_type>(m, "ast_loop_type")


### PR DESCRIPTION
This PR adds the missing mark node to the wrapper for the ast_node_type enum.

Addresses #126 