### PR TITLE
Support using system CMake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,13 @@ requires = [
     "setuptools>=64;python_version>='3.12'",
 
     "wheel>=0.34.2",
-    "cmake>=3.18",
     "scikit-build",
     "nanobind>=1.3",
-    "ninja",
     "pcpp",
+
+    # Added dynamically in setup.py if needed
+    # "cmake>=3.18",
+    # "ninja",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import shutil
 import sys
 from typing import List, Sequence
 
@@ -275,6 +276,12 @@ def main():
 
     gen_wrapper(isl_inc_dirs, include_barvinok=conf["USE_BARVINOK"])
 
+    setup_requires = []
+    if shutil.which("cmake") is None:
+        setup_requires += ["cmake>=3.18"]
+    if shutil.which("ninja") is None:
+        setup_requires += ["ninja"]
+
     setup(name="islpy",
           version=conf["VERSION_TEXT"],
           description="Wrapper around isl, an integer set library",
@@ -304,6 +311,7 @@ def main():
           packages=find_packages(),
 
           python_requires="~=3.8",
+          setup_requires=setup_requires,
           extras_require={
               "test": ["pytest>=2"],
               },


### PR DESCRIPTION
Declare dependencies on PyPI `cmake` and `ninja` packages only if the system versions of the respective tools are not available, in order to facilitate using the system tools.  This avoids unnecessary dependencies on third-party binaries, and improves portability by allowing the users to benefit from downstream CMake patching.