### PR TITLE
Build wheels on arm64 runners too

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,10 +37,7 @@ jobs:
 
   build_sdist:
     name: Build source distribution
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, ubuntu-22.04-arm]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-13, macos-14, ubuntu-22.04-arm]
 
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,10 @@ jobs:
 
   build_sdist:
     name: Build source distribution
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04-arm]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,7 +53,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-sdist
+          name: cibw-sdist-${{ matrix.os }}
           path: dist/*.tar.gz
 
   upload_pypi:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-sdist-${{ matrix.os }}
+          name: cibw-sdist
           path: dist/*.tar.gz
 
   upload_pypi:


### PR DESCRIPTION
This PR enables CI on Github-hosted arm64 runners that are now [available for free](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) in public repositories


At the moment, I don't know if the `upload_pypi` and `upload_testpypi` jobs will pass, as I couldn't get them to run on my fork due to access token issues.