### PR TITLE
Stop explicitly specifying cibw archs for macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,6 @@ skip = ["pp*", "cp3[67]-*", "*_i686"]
 test-requires = "pytest"
 test-command = "pytest {project}/test"
 
-[tool.cibuildwheel.macos]
-archs = "x86_64 arm64"
-
 [tool.cibuildwheel.macos.environment]
 # Needed for full C++17 support
 MACOSX_DEPLOYMENT_TARGET = "10.14"


### PR DESCRIPTION
x-ref https://github.com/pypa/cibuildwheel/issues/1896#issuecomment-2189434594

closes gh-162