### PR TITLE
Drop arguments to pybind none for due to backward incompatible changes in nanobind 3

### DIFF
--- a/gen_wrap.py
+++ b/gen_wrap.py
@@ -1466,7 +1466,7 @@ def write_exposer(
             f"       new (t) isl::{wrap_class}(result);"
             "    else"
             f'       isl::handle_isl_error(ctx, "isl_{meth.cls}_read_from_str");'
-            '}, py::arg("s"), py::arg("context").none(true)=py::none());\n')
+            '}, py::arg("s"), py::arg("context").none()=py::none());\n')
 
 # }}}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "scikit_build_core.build"
 requires = [
     "scikit-build-core >=0.9.3",
-    "nanobind >=2.15",
+    "nanobind >=3.0",
     "pcpp",
 
     # stubgen uses @override :/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
 
 [project]
 name = "islpy"
-version = "2026.2"
+version = "2026.2.1"
 description = "Wrapper around isl, an integer set library"
 readme = "README.rst"
 license = "MIT"

--- a/src/wrapper/wrap_isl_part1.cpp
+++ b/src/wrapper/wrap_isl_part1.cpp
@@ -101,7 +101,7 @@ void islpy_expose_part1(py::module_ &m)
           new (t) isl::val(result);
         else
           isl::handle_isl_error(ctx, "isl_val_from_si");
-      }, py::arg("i"), py::arg("context").none(true)=py::none()
+      }, py::arg("i"), py::arg("context").none()=py::none()
       );
 
   MAKE_WRAP(multi_val, MultiVal);
@@ -151,8 +151,8 @@ void islpy_expose_part1(py::module_ &m)
         else
           isl::handle_isl_error(ctx, "isl_id_alloc");
       }, py::arg("name"),
-      py::arg("user").none(true)=py::none(),
-      py::arg("context").none(true)=py::none()
+      py::arg("user").none()=py::none(),
+      py::arg("context").none()=py::none()
       );
   wrap_id.def("__eq__", islpy::id_eq, py::arg("other"),
       "__eq__(self, other)\n\n"


### PR DESCRIPTION
Fixes #220 

I have verified this by building locally and running CI on my fork. However, I have no actual knowledge of the codebase, and in particular I do not understand the implications of passing the `true` argument to `none` in pybind 2.x.

`pyopencl` may need a similar fix (as highlighted by the `Tests for downstream project loopy` CI job failing on my fork), but I didn't need that for firedrake's stack so I didn't prepare a similar patch there.